### PR TITLE
fix import into documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ We use [SemVer](https://semver.org/) for versioning. For the versions available,
 
 ## Issues ##
 
-If you find any issues feel free to open a request in [the Issues tab](https://github.com/jrquick17/ionic4-auto-complete/issues). If I have the time I will try to solve any issues but cannot make any guarantees. Feel free to contribute yourself.
+If you find any issues feel free to open a request in [the Issues tab](https://github.com/jrquick17/ionic4-tooltips/issues). If I have the time I will try to solve any issues but cannot make any guarantees. Feel free to contribute yourself.
 
 ### Demo ###
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ npm install ionic4-tooltips --save
 2.  Import `TooltipsModule` in your `@NgModule`. If you are using lazy module loading, then you need to import it in the modules where it's used.
 
 ```ts
-import { TooltipsModule } from 'ionic-tooltips';
+import { TooltipsModule } from 'ionic4-tooltips';
 
 @NgModule({
    ...


### PR DESCRIPTION
Import was incorrect into documenation.
replace `import { TooltipsModule } from "ionic-tooltips"` by `import { TooltipsModule } from "ionic4-tooltips"`